### PR TITLE
fixed name of function so it works with Amazon Lambda

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -131,7 +131,7 @@ class ResultReporter:
                 print(f"Failed to publish metrics to CloudWatch:{e}")
 
 
-def port_check(event, context):
+def lambda_handler(event, context):
     """Lambda function handler"""
 
     config = Config(event)


### PR DESCRIPTION
maybe it didn't use to matter, but the main function of your python script needs to be 'lambda_handler' now in Amazon Lambda